### PR TITLE
feat: initial commit

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.github
+.env
+.env.example
+.gitignore
+.dockerignore
+*.md
+LICENSE
+Makefile
+test_cluster.sh
+tests/
+venv/
+volumes/

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Slurm version (semantic version format)
+# Supported versions: 25.11.x, 25.05.x, 24.11.x
+SLURM_VERSION=25.11.2
+
+# MySQL credentials (only for local development/testing)
+MYSQL_USER=slurm
+MYSQL_PASSWORD=password

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,39 @@
+name: Publish Docker Image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read Slurm version from .env.example
+        id: config
+        run: |
+          echo "slurm_version=$(grep '^SLURM_VERSION=' .env.example | cut -d= -f2)" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-qemu-action@v4
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push multi-arch image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            SLURM_VERSION=${{ steps.config.outputs.slurm_version }}
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/slurm-docker:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/slurm-docker:${{ steps.config.outputs.slurm_version }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/slurm-docker:${{ steps.config.outputs.slurm_version }}-${{ github.event.release.tag_name }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,61 @@
+name: Test Slurm Container
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        slurm_version: ['25.11.2', '25.05.6', '24.11.7']
+        runner: ['ubuntu-latest']
+        include:
+          - runner: ubuntu-latest
+            arch: amd64
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build image - Slurm ${{ matrix.slurm_version }} (${{ matrix.arch }})
+        run: |
+          echo "SLURM_VERSION=${{ matrix.slurm_version }}" > .env
+          docker compose build
+
+      - name: Start container
+        run: |
+          docker compose up -d
+          echo "Waiting for services to start..."
+          sleep 30
+
+      - name: Wait for Slurm to be ready
+        run: |
+          timeout 120 bash -c 'until docker exec slurm scontrol ping 2>/dev/null | grep -q "UP"; do
+            echo "Waiting for slurmctld..."
+            sleep 5
+          done'
+          echo "slurmctld is ready"
+
+      - name: Show status
+        run: |
+          docker compose ps
+          docker exec slurm sinfo || true
+          docker exec slurm scontrol show nodes || true
+
+      - name: Run test suite
+        run: chmod +x test_cluster.sh && ./test_cluster.sh
+
+      - name: Show logs on failure
+        if: failure()
+        run: docker compose logs
+
+      - name: Cleanup
+        if: always()
+        run: docker compose down -v -t 3

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,70 @@
+# Docker volumes and data
+*.log
+
+# Environment files
+.env
+.env.local
+.env.*.local
+
+# IDE and Editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.project
+.classpath
+.settings/
+*.sublime-project
+*.sublime-workspace
+
+# OS specific files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+desktop.ini
+
+# Temporary files
+*.tmp
+*.bak
+*.cache
+.temp/
+tmp/
+
+# Build artifacts
+*.tar
+*.tar.gz
+*.zip
+
+# Local testing files
+test-output/
+*.test
+
+# Git
+*.orig
+*.rej
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+*.egg-info/
+dist/
+build/
+
+# Backup files
+*.backup
+*~
+
+# Local overrides
+docker-compose.override.yml
+
+rpmbuild/
+archive/
+.claude/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,248 @@
+# Multi-stage Dockerfile for all-in-one Slurm container on Rocky Linux 10
+# Stage 1: Build gosu from source with latest Go
+# Stage 2: Build Slurm RPMs
+# Stage 3: Runtime image with bash entrypoint
+
+ARG SLURM_VERSION
+ARG GOSU_VERSION=1.19
+
+# ============================================================================
+# Stage 1: Build gosu from source
+# (pre-built binaries use an old Go version that triggers CVEs)
+# https://github.com/tianon/gosu/issues/136
+# ============================================================================
+FROM golang:1.26-bookworm AS gosu-builder
+
+ARG GOSU_VERSION
+ARG TARGETOS
+ARG TARGETARCH
+
+RUN set -ex \
+    && git clone --branch ${GOSU_VERSION} --depth 1 \
+       https://github.com/tianon/gosu.git /go/src/github.com/tianon/gosu \
+    && cd /go/src/github.com/tianon/gosu \
+    && go mod download \
+    && CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+       go build -v -trimpath -ldflags '-d -w' \
+       -o /go/bin/gosu . \
+    && chmod +x /go/bin/gosu
+
+# ============================================================================
+# Stage 2: Build RPMs
+# ============================================================================
+FROM rockylinux/rockylinux:10 AS builder
+
+ARG SLURM_VERSION
+ARG TARGETARCH
+
+# Enable CRB and EPEL, install build dependencies
+# http-parser: temporarily using RL9 packages (https://support.schedmd.com/show_bug.cgi?id=21801)
+RUN set -ex \
+    && RPM_ARCH=$(case "${TARGETARCH}" in \
+         amd64) echo "x86_64" ;; \
+         arm64) echo "aarch64" ;; \
+         *) echo "Unsupported architecture: ${TARGETARCH}" && exit 1 ;; \
+       esac) \
+    && dnf makecache \
+    && dnf -y install dnf-plugins-core epel-release wget \
+    && dnf config-manager --set-enabled crb \
+    && dnf makecache \
+    && dnf -y install \
+       https://download.rockylinux.org/pub/rocky/9/AppStream/${RPM_ARCH}/os/Packages/h/http-parser-2.9.4-6.el9.${RPM_ARCH}.rpm \
+       https://download.rockylinux.org/pub/rocky/9/CRB/${RPM_ARCH}/os/Packages/h/http-parser-devel-2.9.4-6.el9.${RPM_ARCH}.rpm \
+    && dnf -y install \
+       autoconf \
+       automake \
+       bzip2 \
+       dbus-devel \
+       freeipmi-devel \
+       gcc \
+       gcc-c++ \
+       git \
+       gtk2-devel \
+       hdf5-devel \
+       hwloc-devel \
+       json-c-devel \
+       libcurl-devel \
+       libyaml-devel \
+       lua-devel \
+       lz4-devel \
+       make \
+       man2html \
+       mariadb-devel \
+       munge \
+       munge-devel \
+       ncurses-devel \
+       numactl-devel \
+       openssl-devel \
+       pam-devel \
+       perl \
+       python3 \
+       python3-devel \
+       readline-devel \
+       rpm-build \
+       rpmdevtools \
+       rrdtool-devel \
+       libjwt-devel \
+    && dnf clean all \
+    && rm -rf /var/cache/dnf
+
+RUN rpmdev-setuptree
+COPY rpmbuild/slurm.rpmmacros /root/.rpmmacros
+
+# Download and build Slurm RPMs
+# Architecture: Docker TARGETARCH (amd64, arm64) -> RPM arch (x86_64, aarch64)
+RUN set -ex \
+    && RPM_ARCH=$(case "${TARGETARCH}" in \
+         amd64) echo "x86_64" ;; \
+         arm64) echo "aarch64" ;; \
+         *) echo "Unsupported: ${TARGETARCH}" && exit 1 ;; \
+       esac) \
+    && wget -O /root/rpmbuild/SOURCES/slurm-${SLURM_VERSION}.tar.bz2 \
+       https://download.schedmd.com/slurm/slurm-${SLURM_VERSION}.tar.bz2 \
+    && rpmbuild -ta /root/rpmbuild/SOURCES/slurm-${SLURM_VERSION}.tar.bz2 \
+    && ls -lh /root/rpmbuild/RPMS/${RPM_ARCH}/
+
+# ============================================================================
+# Stage 3: Runtime image
+# ============================================================================
+FROM rockylinux/rockylinux:10
+
+LABEL org.opencontainers.image.source="https://github.com/giovtorres/slurm-docker" \
+      org.opencontainers.image.title="slurm-docker" \
+      org.opencontainers.image.description="All-in-one Slurm Docker container on Rocky Linux 10" \
+      maintainer="Giovanni Torres"
+
+ARG SLURM_VERSION
+ARG TARGETARCH
+
+# Install runtime dependencies
+# http-parser: temporarily using RL9 package (https://support.schedmd.com/show_bug.cgi?id=21801)
+RUN set -ex \
+    && RPM_ARCH=$(case "${TARGETARCH}" in \
+         amd64) echo "x86_64" ;; \
+         arm64) echo "aarch64" ;; \
+         *) echo "Unsupported: ${TARGETARCH}" && exit 1 ;; \
+       esac) \
+    && dnf makecache \
+    && dnf -y update \
+    && dnf -y install dnf-plugins-core epel-release wget \
+    && dnf config-manager --set-enabled crb \
+    && dnf makecache \
+    && dnf -y install \
+       https://download.rockylinux.org/pub/rocky/9/AppStream/${RPM_ARCH}/os/Packages/h/http-parser-2.9.4-6.el9.${RPM_ARCH}.rpm \
+    && dnf -y install \
+       bash \
+       bash-completion \
+       bzip2 \
+       gettext \
+       hdf5 \
+       hwloc \
+       json-c \
+       jq \
+       libaec \
+       libyaml \
+       lua \
+       lz4 \
+       mariadb \
+       mariadb-server \
+       munge \
+       numactl \
+       perl \
+       procps-ng \
+       psmisc \
+       python3 \
+       readline \
+       vim-enhanced \
+       libjwt \
+       openssh-server \
+       openssh-clients \
+       google-authenticator \
+       passwd \
+    && dnf clean all \
+    && rm -rf /var/cache/dnf
+
+# Install gosu (built from source in stage 1)
+COPY --from=gosu-builder /go/bin/gosu /usr/local/bin/gosu
+RUN gosu --version && gosu nobody true
+
+# Install uv (Python package manager)
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+# Install Slurm RPMs
+COPY --from=builder /root/rpmbuild/RPMS/*/*.rpm /tmp/rpms/
+RUN set -ex \
+    && dnf -y install \
+       /tmp/rpms/slurm-[0-9]*.rpm \
+       /tmp/rpms/slurm-perlapi-*.rpm \
+       /tmp/rpms/slurm-slurmctld-*.rpm \
+       /tmp/rpms/slurm-slurmd-*.rpm \
+       /tmp/rpms/slurm-slurmdbd-*.rpm \
+       /tmp/rpms/slurm-slurmrestd-*.rpm \
+       /tmp/rpms/slurm-contribs-*.rpm \
+    && rm -rf /tmp/rpms \
+    && dnf clean all
+
+# Create users, munge key, and directories
+RUN set -x \
+    && groupadd -r --gid=990 slurm \
+    && useradd -r -g slurm --uid=990 slurm \
+    && groupadd -r --gid=991 slurmrest \
+    && useradd -r -g slurmrest --uid=991 slurmrest \
+    && chmod 0755 /etc \
+    && /sbin/mungekey --create \
+    && chown munge:munge /etc/munge/munge.key \
+    && chmod 0400 /etc/munge/munge.key \
+    && mkdir -m 0755 -p \
+        /var/run/slurm \
+        /var/spool/slurm \
+        /var/lib/slurm \
+        /var/log/slurm \
+        /etc/slurm \
+        /data \
+    && chown slurm:slurm \
+        /var/run/slurm \
+        /var/spool/slurm \
+        /var/lib/slurm \
+        /var/log/slurm \
+        /etc/slurm
+
+# Copy Slurm configuration files (version-specific selection)
+COPY config/ /tmp/slurm-config/
+RUN set -ex \
+    && MAJOR_MINOR=$(echo ${SLURM_VERSION} | cut -d. -f1,2) \
+    && echo "Slurm version: ${MAJOR_MINOR}" \
+    && if [ -f "/tmp/slurm-config/${MAJOR_MINOR}/slurm.conf" ]; then \
+         echo "Using config for ${MAJOR_MINOR}"; \
+         cp /tmp/slurm-config/${MAJOR_MINOR}/slurm.conf /etc/slurm/slurm.conf; \
+       else \
+         echo "No config for ${MAJOR_MINOR}, falling back to 25.11"; \
+         cp /tmp/slurm-config/25.11/slurm.conf /etc/slurm/slurm.conf; \
+       fi \
+    && cp /tmp/slurm-config/common/slurmdbd.conf /etc/slurm/slurmdbd.conf \
+    && cp /tmp/slurm-config/common/cgroup.conf /etc/slurm/cgroup.conf \
+    && chown slurm:slurm /etc/slurm/slurm.conf /etc/slurm/cgroup.conf /etc/slurm/slurmdbd.conf \
+    && chmod 644 /etc/slurm/slurm.conf /etc/slurm/cgroup.conf \
+    && chmod 600 /etc/slurm/slurmdbd.conf \
+    && rm -rf /tmp/slurm-config
+
+# SSH: generate host keys, install default passwordless config, remove root password
+COPY config/common/sshd_config /etc/ssh/sshd_config
+RUN set -ex \
+    && ssh-keygen -A \
+    && mkdir -p /run/sshd /root/.ssh \
+    && chmod 700 /root/.ssh
+
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+EXPOSE 22 6817 6819 6820
+
+WORKDIR /data
+
+VOLUME ["/var/lib/mysql", "/var/log/slurm", "/data"]
+
+# Multi-arch build:
+#   docker buildx build --platform linux/amd64,linux/arm64 .
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,126 @@
+.PHONY: help build up down clean logs test status shell rebuild jobs quick-test version set-version build-all test-version test-all
+
+.DEFAULT_GOAL := help
+
+SUPPORTED_VERSIONS := 24.11.7 25.05.6 25.11.2
+DEFAULT_VERSION := 25.11.2
+
+CYAN := $(shell tput -Txterm setaf 6)
+RESET := $(shell tput -Txterm sgr0)
+
+help:  ## Show this help message
+	@echo "Slurm Docker (All-in-One) - Available Commands"
+	@echo "==============================================="
+	@echo ""
+	@echo "Cluster Management:"
+	@printf "  ${CYAN}%-15s${RESET} %s\n" "build" "Build Docker image"
+	@printf "  ${CYAN}%-15s${RESET} %s\n" "up" "Start container"
+	@printf "  ${CYAN}%-15s${RESET} %s\n" "down" "Stop container"
+	@printf "  ${CYAN}%-15s${RESET} %s\n" "clean" "Remove container and volumes"
+	@printf "  ${CYAN}%-15s${RESET} %s\n" "rebuild" "Clean, rebuild, and start"
+	@echo ""
+	@echo "Quick Commands:"
+	@printf "  ${CYAN}%-15s${RESET} %s\n" "shell" "Open shell in container"
+	@printf "  ${CYAN}%-15s${RESET} %s\n" "status" "Show cluster status"
+	@printf "  ${CYAN}%-15s${RESET} %s\n" "jobs" "View job queue"
+	@printf "  ${CYAN}%-15s${RESET} %s\n" "quick-test" "Submit a quick test job"
+	@printf "  ${CYAN}%-15s${RESET} %s\n" "logs" "Show container logs"
+	@echo ""
+	@echo "Testing:"
+	@printf "  ${CYAN}%-15s${RESET} %s\n" "test" "Run test suite"
+	@printf "  ${CYAN}%-15s${RESET} %s\n" "test-version" "Test specific version (VER=...)"
+	@printf "  ${CYAN}%-15s${RESET} %s\n" "test-all" "Test all supported versions"
+	@echo ""
+	@echo "Multi-Version:"
+	@printf "  ${CYAN}%-15s${RESET} %s\n" "version" "Show current Slurm version"
+	@printf "  ${CYAN}%-15s${RESET} %s\n" "set-version" "Set Slurm version (VER=...)"
+	@printf "  ${CYAN}%-15s${RESET} %s\n" "build-all" "Build all supported versions"
+	@echo ""
+	@echo "Examples:"
+	@echo "  make set-version VER=24.11.7"
+	@echo "  make test-version VER=25.05.6"
+
+build:  ## Build Docker image
+	docker compose --progress plain build
+
+up:  ## Start container
+	docker compose up -d
+
+down:  ## Stop container
+	docker compose down
+
+clean:  ## Remove container and volumes
+	docker compose down -v
+
+logs:  ## Show container logs
+	docker compose logs -f
+
+test:  ## Run test suite
+	./test_cluster.sh
+
+status:  ## Show cluster status
+	@echo "=== Container ==="
+	@docker compose ps
+	@echo ""
+	@echo "=== Cluster ==="
+	@docker exec slurm sinfo 2>/dev/null || echo "Not ready"
+
+shell:  ## Open shell in container
+	docker exec -it slurm bash
+
+quick-test:  ## Submit a quick test job
+	docker exec slurm bash -c "cd /data && sbatch --wrap='hostname' && sleep 3 && squeue && cat slurm-*.out 2>/dev/null | tail -5"
+
+jobs:  ## View job queue
+	docker exec slurm squeue
+
+version:  ## Show current Slurm version
+	@if [ -f .env ]; then \
+		grep SLURM_VERSION .env || echo "SLURM_VERSION not set (default: $(DEFAULT_VERSION))"; \
+	else \
+		echo "No .env file (default: $(DEFAULT_VERSION))"; \
+	fi
+
+set-version:  ## Set Slurm version (usage: make set-version VER=24.11.7)
+	@if [ -z "$(VER)" ]; then \
+		echo "Usage: make set-version VER=24.11.7"; \
+		echo "Supported: $(SUPPORTED_VERSIONS)"; \
+		exit 1; \
+	fi
+	@echo "SLURM_VERSION=$(VER)" > .env
+	@echo "Set SLURM_VERSION=$(VER) — run 'make rebuild' to apply"
+
+build-all:  ## Build images for all supported versions
+	@for version in $(SUPPORTED_VERSIONS); do \
+		echo ""; \
+		echo "======== Building Slurm $$version ========"; \
+		echo "SLURM_VERSION=$$version" > .env; \
+		docker compose build || exit 1; \
+		echo "Built slurm-docker:$$version"; \
+	done
+	@echo ""
+	@echo "All versions built"
+
+test-version:  ## Test a specific version (usage: make test-version VER=24.11.7)
+	@if [ -z "$(VER)" ]; then \
+		echo "Usage: make test-version VER=24.11.7"; \
+		echo "Supported: $(SUPPORTED_VERSIONS)"; \
+		exit 1; \
+	fi
+	@echo "======== Testing Slurm $(VER) ========"
+	@echo "SLURM_VERSION=$(VER)" > .env
+	@$(MAKE) clean
+	@docker compose up -d
+	@echo "Waiting for services to start..."
+	@sleep 30
+	@./test_cluster.sh
+	@$(MAKE) clean
+
+test-all:  ## Test all supported versions
+	@for version in $(SUPPORTED_VERSIONS); do \
+		$(MAKE) test-version VER=$$version || exit 1; \
+	done
+	@echo ""
+	@echo "All version tests passed"
+
+rebuild: clean build up

--- a/config/24.11/slurm.conf
+++ b/config/24.11/slurm.conf
@@ -1,0 +1,50 @@
+# slurm.conf - Slurm 24.11.x configuration (single container)
+# GetEnvTimeout is enabled (deprecated in 25.05+)
+#
+ClusterName=linux
+SlurmctldHost=slurmctl
+
+ProctrackType=proctrack/linuxproc
+ReturnToService=1
+SlurmdParameters=config_overrides
+SlurmctldPidFile=/var/run/slurm/slurmctld.pid
+SlurmctldPort=6817
+SlurmdPidFile=/var/run/slurm/slurmd-%n.pid
+SlurmdSpoolDir=/var/spool/slurm/%n
+SlurmUser=slurm
+StateSaveLocation=/var/lib/slurm
+TaskPlugin=task/affinity
+
+# TIMERS
+GetEnvTimeout=2
+InactiveLimit=0
+KillWait=30
+MinJobAge=300
+SlurmctldTimeout=120
+SlurmdTimeout=300
+Waittime=0
+
+# SCHEDULING
+SchedulerType=sched/backfill
+SelectType=select/cons_tres
+
+# LOGGING AND ACCOUNTING
+AccountingStorageHost=localhost
+AccountingStorageType=accounting_storage/slurmdbd
+JobCompLoc=/var/log/slurm/jobcomp.log
+JobCompType=jobcomp/filetxt
+JobAcctGatherFrequency=30
+SlurmctldDebug=info
+SlurmctldLogFile=/var/log/slurm/slurmctld.log
+SlurmdDebug=info
+SlurmdLogFile=/var/log/slurm/slurmd-%n.log
+
+# AUTHENTICATION
+AuthType=auth/munge
+AuthAltTypes=auth/jwt
+AuthAltParameters=jwt_key=/etc/slurm/jwt_hs256.key
+
+# COMPUTE NODES (3 simulated nodes on localhost with different ports)
+NodeName=node[1-3] NodeAddr=127.0.0.1 Port=[7001-7003] CPUs=2 RealMemory=1000 State=UNKNOWN
+
+PartitionName=normal Nodes=node[1-3] Default=YES MaxTime=INFINITE State=UP

--- a/config/25.05/slurm.conf
+++ b/config/25.05/slurm.conf
@@ -1,0 +1,48 @@
+# slurm.conf - Slurm 25.05.x configuration (single container)
+#
+ClusterName=linux
+SlurmctldHost=slurmctl
+
+ProctrackType=proctrack/linuxproc
+ReturnToService=1
+SlurmdParameters=config_overrides
+SlurmctldPidFile=/var/run/slurm/slurmctld.pid
+SlurmctldPort=6817
+SlurmdPidFile=/var/run/slurm/slurmd-%n.pid
+SlurmdSpoolDir=/var/spool/slurm/%n
+SlurmUser=slurm
+StateSaveLocation=/var/lib/slurm
+TaskPlugin=task/affinity
+
+# TIMERS
+InactiveLimit=0
+KillWait=30
+MinJobAge=300
+SlurmctldTimeout=120
+SlurmdTimeout=300
+Waittime=0
+
+# SCHEDULING
+SchedulerType=sched/backfill
+SelectType=select/cons_tres
+
+# LOGGING AND ACCOUNTING
+AccountingStorageHost=localhost
+AccountingStorageType=accounting_storage/slurmdbd
+JobCompLoc=/var/log/slurm/jobcomp.log
+JobCompType=jobcomp/filetxt
+JobAcctGatherFrequency=30
+SlurmctldDebug=info
+SlurmctldLogFile=/var/log/slurm/slurmctld.log
+SlurmdDebug=info
+SlurmdLogFile=/var/log/slurm/slurmd-%n.log
+
+# AUTHENTICATION
+AuthType=auth/munge
+AuthAltTypes=auth/jwt
+AuthAltParameters=jwt_key=/etc/slurm/jwt_hs256.key
+
+# COMPUTE NODES (3 simulated nodes on localhost with different ports)
+NodeName=node[1-3] NodeAddr=127.0.0.1 Port=[7001-7003] CPUs=2 RealMemory=1000 State=UNKNOWN
+
+PartitionName=normal Nodes=node[1-3] Default=YES MaxTime=INFINITE State=UP

--- a/config/25.11/slurm.conf
+++ b/config/25.11/slurm.conf
@@ -1,0 +1,48 @@
+# slurm.conf - Slurm 25.11.x configuration (single container)
+#
+ClusterName=linux
+SlurmctldHost=slurmctl
+
+ProctrackType=proctrack/linuxproc
+ReturnToService=1
+SlurmdParameters=config_overrides
+SlurmctldPidFile=/var/run/slurm/slurmctld.pid
+SlurmctldPort=6817
+SlurmdPidFile=/var/run/slurm/slurmd-%n.pid
+SlurmdSpoolDir=/var/spool/slurm/%n
+SlurmUser=slurm
+StateSaveLocation=/var/lib/slurm
+TaskPlugin=task/affinity
+
+# TIMERS
+InactiveLimit=0
+KillWait=30
+MinJobAge=300
+SlurmctldTimeout=120
+SlurmdTimeout=300
+Waittime=0
+
+# SCHEDULING
+SchedulerType=sched/backfill
+SelectType=select/cons_tres
+
+# LOGGING AND ACCOUNTING
+AccountingStorageHost=localhost
+AccountingStorageType=accounting_storage/slurmdbd
+JobCompLoc=/var/log/slurm/jobcomp.log
+JobCompType=jobcomp/filetxt
+JobAcctGatherFrequency=30
+SlurmctldDebug=info
+SlurmctldLogFile=/var/log/slurm/slurmctld.log
+SlurmdDebug=info
+SlurmdLogFile=/var/log/slurm/slurmd-%n.log
+
+# AUTHENTICATION
+AuthType=auth/munge
+AuthAltTypes=auth/jwt
+AuthAltParameters=jwt_key=/etc/slurm/jwt_hs256.key
+
+# COMPUTE NODES (3 simulated nodes on localhost with different ports)
+NodeName=node[1-3] NodeAddr=127.0.0.1 Port=[7001-7003] CPUs=2 RealMemory=1000 State=UNKNOWN
+
+PartitionName=normal Nodes=node[1-3] Default=YES MaxTime=INFINITE State=UP

--- a/config/common/cgroup.conf
+++ b/config/common/cgroup.conf
@@ -1,0 +1,6 @@
+ConstrainCores=no
+ConstrainDevices=no
+ConstrainRAMSpace=no
+ConstrainSwapSpace=no
+IgnoreSystemd=yes
+IgnoreSystemdOnFailure=yes

--- a/config/common/slurmdbd.conf
+++ b/config/common/slurmdbd.conf
@@ -1,0 +1,22 @@
+# slurmdbd.conf - Slurm Database Daemon configuration (single container)
+#
+AuthType=auth/munge
+
+DbdAddr=localhost
+DbdHost=localhost
+DbdPort=6819
+SlurmUser=slurm
+DebugLevel=4
+LogFile=/var/log/slurm/slurmdbd.log
+PidFile=/var/run/slurm/slurmdbd.pid
+
+# Database info (variables substituted at runtime by init-slurm.sh)
+StorageType=accounting_storage/mysql
+StorageHost=localhost
+StorageUser=${MYSQL_USER}
+StoragePass=${MYSQL_PASSWORD}
+StorageLoc=slurm_acct_db
+
+# JWT authentication for REST API
+AuthAltTypes=auth/jwt
+AuthAltParameters=jwt_key=/etc/slurm/jwt_hs256.key

--- a/config/common/sshd_config
+++ b/config/common/sshd_config
@@ -1,0 +1,46 @@
+# sshd_config - Default SSH for Slurm container
+#
+# Customization options (in order of preference):
+#   1. Mount a custom file to /etc/ssh/sshd_config (full control)
+#   2. Use environment variables for common settings (see below)
+#
+# Environment variables (applied at startup by docker-entrypoint.sh):
+#   SSH_PERMIT_ROOT_LOGIN    - yes|no|prohibit-password (default: prohibit-password)
+#   SSH_PASSWORD_AUTH        - yes|no (default: no)
+#   SSH_PORT                 - port number (default: 22)
+#   ROOT_PASSWORD            - if set, enables root login with this password
+
+Port 22
+ListenAddress 0.0.0.0
+
+# Authentication
+PermitRootLogin prohibit-password
+PubkeyAuthentication yes
+AuthorizedKeysFile .ssh/authorized_keys
+PasswordAuthentication no
+PermitEmptyPasswords no
+KbdInteractiveAuthentication no
+GSSAPIAuthentication no
+
+# CI/CD friendly defaults (no throttling)
+MaxStartups 100:30:200
+LoginGraceTime 120
+MaxAuthTries 20
+UseDNS no
+
+# Accept environment variables from Slurm
+AcceptEnv LANG LC_* SLURM_* COLORTERM NO_COLOR
+
+# Logging
+SyslogFacility AUTHPRIV
+LogLevel INFO
+
+# Keep connections alive
+ClientAliveInterval 60
+ClientAliveCountMax 3
+
+# X11 forwarding (off by default)
+X11Forwarding no
+
+# Subsystems
+Subsystem sftp /usr/libexec/openssh/sftp-server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+services:
+  slurm:
+    build:
+      context: .
+      args:
+        SLURM_VERSION: ${SLURM_VERSION:-25.11.2}
+    image: slurm-docker:${SLURM_VERSION:-25.11.2}
+    hostname: slurmctl
+    container_name: slurm
+    init: true
+    privileged: true
+    environment:
+      MYSQL_USER: ${MYSQL_USER:-slurm}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:-password}
+    volumes:
+      - var_lib_mysql:/var/lib/mysql
+      - var_log_slurm:/var/log/slurm
+      - slurm_data:/data
+    ports:
+      - "6820:6820"
+      - "2222:22"
+
+volumes:
+  var_lib_mysql:
+  var_log_slurm:
+  slurm_data:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,163 @@
+#!/bin/bash
+set -e
+
+PIDS=()
+
+cleanup() {
+    echo "Shutting down..."
+    # Stop in reverse dependency order
+    for pid in "${PIDS[@]}"; do
+        kill "$pid" 2>/dev/null || true
+    done
+    wait
+    exit 0
+}
+trap cleanup SIGTERM SIGINT
+
+wait_for_port() {
+    local port=$1 name=$2 timeout=${3:-60}
+    echo "-- Waiting for $name (port $port)..."
+    for i in $(seq 1 "$timeout"); do
+        if bash -c "echo >/dev/tcp/localhost/$port" 2>/dev/null; then
+            echo "-- $name is ready"
+            return 0
+        fi
+        sleep 1
+    done
+    echo "ERROR: $name did not become ready within ${timeout}s"
+    exit 1
+}
+
+# --- Munge ---
+echo "---> Starting munged..."
+mkdir -p /run/munge
+chown munge:munge /run/munge
+chmod 0755 /run/munge
+if [ -f /etc/munge/munge.key ]; then
+    chown munge:munge /etc/munge/munge.key
+    chmod 0400 /etc/munge/munge.key
+fi
+gosu munge /usr/sbin/munged -F &
+PIDS+=($!)
+# Wait for munge socket
+for i in $(seq 1 30); do
+    [ -S /run/munge/munge.socket.2 ] && break
+    sleep 1
+done
+
+# --- Extra packages ---
+if [ -n "${EXTRA_PACKAGES:-}" ]; then
+    echo "---> Installing extra packages: ${EXTRA_PACKAGES}"
+    dnf -y install ${EXTRA_PACKAGES}
+fi
+
+# --- SSH ---
+echo "---> Configuring sshd..."
+# Apply SSH environment variables to sshd_config (only if using default config)
+if grep -q 'Environment variables (applied at startup' /etc/ssh/sshd_config 2>/dev/null; then
+    [ -n "${SSH_PORT:-}" ] && \
+        sed -i "s/^Port .*/Port ${SSH_PORT}/" /etc/ssh/sshd_config
+    [ -n "${SSH_PERMIT_ROOT_LOGIN:-}" ] && \
+        sed -i "s/^PermitRootLogin .*/PermitRootLogin ${SSH_PERMIT_ROOT_LOGIN}/" /etc/ssh/sshd_config
+    [ "${SSH_PASSWORD_AUTH:-}" = "yes" ] && \
+        sed -i "s/^PasswordAuthentication .*/PasswordAuthentication yes/" /etc/ssh/sshd_config
+fi
+# Set root password if provided
+if [ -n "${ROOT_PASSWORD:-}" ]; then
+    echo "root:${ROOT_PASSWORD}" | chpasswd
+    echo "-- Root password set"
+fi
+echo "---> Starting sshd..."
+/usr/sbin/sshd -e &
+PIDS+=($!)
+
+# --- MariaDB ---
+echo "---> Starting MariaDB..."
+if [ ! -d "/var/lib/mysql/mysql" ]; then
+    echo "-- Initializing database..."
+    mysql_install_db --user=mysql --datadir=/var/lib/mysql
+fi
+/usr/libexec/mariadbd --user=mysql --skip-name-resolve --skip-host-cache &
+PIDS+=($!)
+
+echo "-- Waiting for MariaDB..."
+for i in $(seq 1 60); do
+    if mysqladmin ping --silent 2>/dev/null; then
+        break
+    fi
+    sleep 1
+done
+
+MYSQL_USER="${MYSQL_USER:-slurm}"
+MYSQL_PASSWORD="${MYSQL_PASSWORD:-password}"
+echo "-- Creating Slurm database if needed..."
+mysql -e "CREATE USER IF NOT EXISTS '${MYSQL_USER}'@'localhost' IDENTIFIED BY '${MYSQL_PASSWORD}'"
+mysql -e "CREATE USER IF NOT EXISTS '${MYSQL_USER}'@'slurmctl' IDENTIFIED BY '${MYSQL_PASSWORD}'"
+mysql -e "GRANT ALL ON slurm_acct_db.* TO '${MYSQL_USER}'@'localhost' WITH GRANT OPTION"
+mysql -e "GRANT ALL ON slurm_acct_db.* TO '${MYSQL_USER}'@'slurmctl' WITH GRANT OPTION"
+mysql -e "CREATE DATABASE IF NOT EXISTS slurm_acct_db"
+
+# --- JWT key ---
+if [ ! -f /etc/slurm/jwt_hs256.key ]; then
+    dd if=/dev/random of=/etc/slurm/jwt_hs256.key bs=32 count=1 2>/dev/null
+    chown slurm:slurm /etc/slurm/jwt_hs256.key
+    chmod 0600 /etc/slurm/jwt_hs256.key
+    echo "-- JWT key generated"
+fi
+
+# --- envsubst slurmdbd.conf ---
+if grep -q '${MYSQL_' /etc/slurm/slurmdbd.conf 2>/dev/null; then
+    envsubst < /etc/slurm/slurmdbd.conf > /etc/slurm/slurmdbd.conf.tmp
+    mv /etc/slurm/slurmdbd.conf.tmp /etc/slurm/slurmdbd.conf
+    chown slurm:slurm /etc/slurm/slurmdbd.conf
+    chmod 600 /etc/slurm/slurmdbd.conf
+fi
+
+# --- slurmdbd ---
+echo "---> Starting slurmdbd..."
+gosu slurm /usr/sbin/slurmdbd -Dvvv &
+PIDS+=($!)
+wait_for_port 6819 "slurmdbd"
+
+# --- slurmctld ---
+echo "---> Starting slurmctld..."
+gosu slurm /usr/sbin/slurmctld -i -Dvvv &
+PIDS+=($!)
+for i in $(seq 1 60); do
+    if scontrol ping 2>/dev/null | grep -q "UP"; then
+        echo "-- slurmctld is ready"
+        break
+    fi
+    sleep 1
+done
+
+# --- slurmd (3 nodes) ---
+echo "---> Starting slurmd instances..."
+# Pre-create per-node spool directories (SlurmdSpoolDir=/var/spool/slurm/%n)
+for n in 1 2 3; do
+    mkdir -p "/var/spool/slurm/node${n}"
+    chown slurm:slurm "/var/spool/slurm/node${n}"
+done
+# Start slurmd instances with staggered delay to avoid cgroup v2 race condition
+for n in 1 2 3; do
+    /usr/sbin/slurmd -Dvvv -N "node${n}" &
+    PIDS+=($!)
+    sleep 1
+done
+
+# --- slurmrestd ---
+echo "---> Starting slurmrestd..."
+mkdir -p /var/run/slurmrestd
+chown slurmrest:slurmrest /var/run/slurmrestd
+SLURM_JWT=daemon gosu slurmrest /usr/sbin/slurmrestd -vvv \
+    unix:/var/run/slurmrestd/slurmrestd.socket 0.0.0.0:6820 &
+PIDS+=($!)
+
+echo "---> All services started"
+
+# If a command was passed (e.g. bash), exec it; otherwise wait
+if [ $# -gt 0 ]; then
+    exec "$@"
+else
+    wait
+fi

--- a/rpmbuild/slurm.rpmmacros
+++ b/rpmbuild/slurm.rpmmacros
@@ -1,0 +1,10 @@
+# Slurm RPM Build Macros
+# See: https://slurm.schedmd.com/quickstart_admin.html#rpmbuild
+
+%_prefix           /usr
+%_slurm_sysconfdir /etc/slurm
+%_libdir           /usr/lib64
+%_with_slurmrestd 1
+%with_mysql        "--with-mysql_config=/usr/bin"
+%_without_ofed 1
+%_with_multiple_slurmd 1

--- a/test_cluster.sh
+++ b/test_cluster.sh
@@ -1,0 +1,218 @@
+#!/bin/bash
+set -e
+
+CI_MODE=${CI:-false}
+
+if [ "$CI_MODE" = "true" ]; then
+    RED='' GREEN='' YELLOW='' BLUE='' NC=''
+else
+    RED='\033[0;31m' GREEN='\033[0;32m' YELLOW='\033[1;33m' BLUE='\033[0;34m' NC='\033[0m'
+fi
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+CONTAINER="slurm"
+
+print_header() { echo -e "${BLUE}================================${NC}\n${BLUE}$1${NC}\n${BLUE}================================${NC}"; }
+print_test() { echo -e "${YELLOW}[TEST]${NC} $1"; TESTS_RUN=$((TESTS_RUN + 1)); }
+print_pass() { echo -e "${GREEN}[PASS]${NC} $1"; TESTS_PASSED=$((TESTS_PASSED + 1)); }
+print_fail() { echo -e "${RED}[FAIL]${NC} $1"; TESTS_FAILED=$((TESTS_FAILED + 1)); }
+print_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
+
+test_container_running() {
+    print_test "Container is running..."
+    if docker compose ps "$CONTAINER" 2>/dev/null | grep -q "Up"; then
+        print_pass "Container is running"
+    else
+        print_fail "Container is not running"
+        return 1
+    fi
+}
+
+test_munge_auth() {
+    print_test "MUNGE authentication..."
+    if docker exec "$CONTAINER" bash -c "munge -n | unmunge" >/dev/null 2>&1; then
+        print_pass "MUNGE authentication works"
+    else
+        print_fail "MUNGE authentication failed"
+        return 1
+    fi
+}
+
+test_mysql_connection() {
+    print_test "MySQL database connection..."
+    if docker exec "$CONTAINER" bash -c "echo 'SELECT 1' | mysql -u\${MYSQL_USER} -p\${MYSQL_PASSWORD} 2>/dev/null" >/dev/null; then
+        print_pass "MySQL connection successful"
+    else
+        print_fail "MySQL connection failed"
+        return 1
+    fi
+}
+
+test_slurmdbd() {
+    print_test "slurmdbd daemon..."
+    if docker exec "$CONTAINER" sacctmgr list cluster -n 2>/dev/null | grep -q "linux"; then
+        print_pass "slurmdbd responding, cluster registered"
+    else
+        print_fail "slurmdbd not responding or cluster not registered"
+        return 1
+    fi
+}
+
+test_slurmctld() {
+    print_test "slurmctld daemon..."
+    if docker exec "$CONTAINER" scontrol ping >/dev/null 2>&1; then
+        print_pass "slurmctld responding"
+    else
+        print_fail "slurmctld not responding"
+        return 1
+    fi
+}
+
+test_compute_nodes() {
+    print_test "Compute nodes availability..."
+    NODE_COUNT=$(docker exec "$CONTAINER" sinfo -N -h 2>/dev/null | wc -l)
+    if [ "$NODE_COUNT" -eq 3 ]; then
+        print_pass "3 compute nodes available"
+    else
+        print_fail "Expected 3 compute nodes, found $NODE_COUNT"
+        return 1
+    fi
+}
+
+test_nodes_idle() {
+    print_test "Compute nodes idle state..."
+    IDLE_NODES=$(docker exec "$CONTAINER" sinfo -h -o "%T" 2>/dev/null | grep -c "idle" || echo "0")
+    if [ "$IDLE_NODES" -ge 1 ]; then
+        print_pass "Nodes in idle state ($IDLE_NODES partitions)"
+    else
+        print_fail "No nodes in idle state"
+        docker exec "$CONTAINER" sinfo 2>/dev/null || true
+        return 1
+    fi
+}
+
+test_partition() {
+    print_test "Partition configuration..."
+    if docker exec "$CONTAINER" sinfo -h 2>/dev/null | grep -q "normal"; then
+        print_pass "Partition 'normal' exists"
+    else
+        print_fail "Partition 'normal' not found"
+        return 1
+    fi
+}
+
+test_job_submission() {
+    print_test "Job submission..."
+    JOB_ID=$(docker exec "$CONTAINER" bash -c "cd /data && sbatch --wrap='hostname' 2>&1" | sed -n 's/.*Submitted batch job \([0-9][0-9]*\).*/\1/p')
+    if [ -n "$JOB_ID" ]; then
+        print_info "  Job ID: $JOB_ID"
+        for i in $(seq 1 30); do
+            JOB_STATE=$(docker exec "$CONTAINER" squeue -j "$JOB_ID" -h -o "%T" 2>/dev/null || echo "COMPLETED")
+            [ "$JOB_STATE" = "COMPLETED" ] || [ -z "$JOB_STATE" ] && break
+            sleep 1
+        done
+        print_pass "Job submitted (ID: $JOB_ID)"
+    else
+        print_fail "Job submission failed"
+        return 1
+    fi
+}
+
+test_job_execution() {
+    print_test "Job execution and output..."
+    OUTPUT=$(docker exec "$CONTAINER" bash -c "cd /data && sbatch --wrap='echo SUCCESS_TEST_\$SLURM_JOB_ID' --wait 2>&1 && sleep 2 && cat slurm-*.out | grep SUCCESS_TEST" 2>/dev/null || echo "")
+    if echo "$OUTPUT" | grep -q "SUCCESS_TEST"; then
+        print_pass "Job executed with output"
+    else
+        print_fail "Job execution failed"
+        return 1
+    fi
+}
+
+test_job_accounting() {
+    print_test "Job accounting..."
+    if docker exec "$CONTAINER" sacct -n --format=JobID -X 2>/dev/null | grep -q "[0-9]"; then
+        print_pass "Job accounting works"
+    else
+        print_fail "No jobs in accounting"
+        return 1
+    fi
+}
+
+test_multi_node_job() {
+    print_test "Multi-node job allocation..."
+    JOB_OUTPUT=$(docker exec "$CONTAINER" bash -c "srun -N 2 hostname" 2>&1 || echo "FAILED")
+    OUTPUT_LINES=$(echo "$JOB_OUTPUT" | grep -v "^$" | wc -l)
+    if [ "$OUTPUT_LINES" -eq 2 ]; then
+        print_pass "Multi-node job ran on 2 nodes"
+    else
+        print_fail "Multi-node job failed"
+        print_info "  Output: $JOB_OUTPUT"
+        return 1
+    fi
+}
+
+test_rest_api() {
+    print_test "REST API (slurmrestd)..."
+
+    # Auto-detect API version from Slurm version
+    SLURM_VER=$(docker exec "$CONTAINER" scontrol version 2>/dev/null | head -1 | grep -oP '\d+\.\d+' || echo "25.11")
+    case "$SLURM_VER" in
+        24.11) API_VERSION="v0.0.41" ;;
+        25.05) API_VERSION="v0.0.42" ;;
+        *)     API_VERSION="v0.0.42" ;;
+    esac
+
+    if docker exec "$CONTAINER" curl -sf --unix-socket /var/run/slurmrestd/slurmrestd.socket \
+        "http://localhost/slurm/${API_VERSION}/ping" >/dev/null 2>&1; then
+        print_pass "REST API responding (${API_VERSION})"
+    else
+        print_fail "REST API not responding"
+        return 1
+    fi
+}
+
+main() {
+    if [ -f .env ]; then
+        SLURM_VERSION=$(grep SLURM_VERSION .env | cut -d= -f2)
+    else
+        SLURM_VERSION="unknown"
+    fi
+
+    print_header "Slurm Docker Test Suite (v${SLURM_VERSION})"
+    echo ""
+
+    test_container_running || true
+    test_munge_auth || true
+    test_mysql_connection || true
+    test_slurmdbd || true
+    test_slurmctld || true
+    test_compute_nodes || true
+    test_nodes_idle || true
+    test_partition || true
+    test_job_submission || true
+    test_job_execution || true
+    test_job_accounting || true
+    test_multi_node_job || true
+    test_rest_api || true
+
+    echo ""
+    print_header "Test Summary"
+    echo -e "Run: ${BLUE}$TESTS_RUN${NC}  Passed: ${GREEN}$TESTS_PASSED${NC}  Failed: ${RED}$TESTS_FAILED${NC}"
+    echo ""
+
+    if [ $TESTS_FAILED -eq 0 ]; then
+        echo -e "${GREEN}All tests passed${NC}"
+        [ "$CI_MODE" = "true" ] && echo "::notice title=Tests::All $TESTS_RUN tests passed"
+        exit 0
+    else
+        echo -e "${RED}$TESTS_FAILED test(s) failed${NC}"
+        [ "$CI_MODE" = "true" ] && echo "::error title=Tests::$TESTS_FAILED/$TESTS_RUN failed"
+        exit 1
+    fi
+}
+
+main


### PR DESCRIPTION
This change adds:
  - Rocky Linux 10 multi-stage Dockerfile: gosu built from source (Go 1.26), Slurm RPMs via rpmbuild -ta,   
  clean runtime image
  - Single-container Slurm cluster: bash entrypoint manages munged, sshd, MariaDB, slurmdbd, slurmctld, 3x  
  slurmd, slurmrestd
  - Multi-version support: version-specific configs in config/{24.11,25.05,25.11}/, selected at build time
  from SLURM_VERSION
  - SSH with env-var configuration: pubkey default, optional password auth (SSH_PASSWORD_AUTH), 2FA-ready,
  CI/CD-friendly defaults
  - Runtime customization: EXTRA_PACKAGES, ROOT_PASSWORD, JWT auth, gosu, uv, envsubst for slurmdbd.conf
  - CI: test matrix across 3 Slurm versions on PR/push; publish workflow for multi-arch Docker Hub push on
  release